### PR TITLE
Allow usbguard_t domain mmap own tmpfs files

### DIFF
--- a/usbguard.te
+++ b/usbguard.te
@@ -85,6 +85,7 @@ files_pid_filetrans(usbguard_t, usbguard_var_run_t, file)
 
 manage_files_pattern(usbguard_t, usbguard_tmpfs_t, usbguard_tmpfs_t)
 fs_tmpfs_filetrans(usbguard_t, usbguard_tmpfs_t, file)
+allow usbguard_t usbguard_tmpfs_t:file map;
 
 manage_files_pattern(usbguard_t, usbguard_log_t, usbguard_log_t)
 logging_log_filetrans(usbguard_t, usbguard_log_t, { file dir })


### PR DESCRIPTION
Resolves: #2

Before:
$ sesearch -A -s usbguard_t -t usbguard_tmpfs_t -c file -p map

After:
$ sesearch -A -s usbguard_t -t usbguard_tmpfs_t -c file -p map
allow usbguard_t usbguard_tmpfs_t:file { append create getattr ioctl link lock *map* open read rename setattr unlink write };