### PR TITLE
Update SELinux policy for USBGuard

### DIFF
--- a/usbguard.te
+++ b/usbguard.te
@@ -41,15 +41,18 @@ gen_tunable(usbguard_daemon_write_rules, true)
 type usbguard_t;
 type usbguard_exec_t;
 init_daemon_domain(usbguard_t, usbguard_exec_t)
+init_nnp_daemon_domain(usbguard_t)
 
 type usbguard_unit_file_t;
 systemd_unit_file(usbguard_unit_file_t)
 
 type usbguard_conf_t;
 files_config_file(usbguard_conf_t)
+systemd_mount_dir(usbguard_conf_t)
 
 type usbguard_log_t;
 logging_log_file(usbguard_log_t)
+systemd_mount_dir(usbguard_log_t)
 
 type usbguard_rules_t;
 files_config_file(usbguard_rules_t)
@@ -84,7 +87,8 @@ manage_files_pattern(usbguard_t, usbguard_var_run_t, usbguard_var_run_t)
 files_pid_filetrans(usbguard_t, usbguard_var_run_t, file)
 
 manage_files_pattern(usbguard_t, usbguard_tmpfs_t, usbguard_tmpfs_t)
-fs_tmpfs_filetrans(usbguard_t, usbguard_tmpfs_t, file)
+fs_tmpfs_filetrans(usbguard_t, usbguard_tmpfs_t, { file dir })
+manage_dirs_pattern(usbguard_t, usbguard_tmpfs_t, usbguard_tmpfs_t)
 allow usbguard_t usbguard_tmpfs_t:file map;
 
 manage_files_pattern(usbguard_t, usbguard_log_t, usbguard_log_t)


### PR DESCRIPTION
Allow usbguard_t to create, read, write, and delete tmpfs directories.

Mark usbguard_log_t as mountable by systemd.

Allow usbguard_t SELinux Domain trasition from sytemd into confined domain with NoNewPrivileges - no_new_privs bit ensures process/children processes do not gain any additional privileges.

USBGuard policy module installed: 

$ sesearch -A -s usbguard_t -t tmpfs_t -c dir -p rmdir
allow usbguard_t tmpfs_t:dir { add_name create getattr ioctl link lock open read remove_name rename reparent rmdir search setattr unlink write };

$ sesearch -A -s init_t -t usbguard_log_t -p mounton
allow init_t systemd_mount_directory:dir mounton;

$ sesearch -A -s init_t -t usbguard_t -c process2
allow init_t usbguard_t:process2 { nnp_transition nosuid_transition };
