### PR TITLE
Rename all /var/run file context entries to /run

### DIFF
--- a/usbguard.fc
+++ b/usbguard.fc
@@ -21,4 +21,4 @@
 /usr/sbin/usbguard-daemon                 -- gen_context(system_u:object_r:usbguard_exec_t,s0)
 /usr/sbin/usbguard-dbus                   -- gen_context(system_u:object_r:usbguard_exec_t,s0)
 /var/log/usbguard(/.*)?                      gen_context(system_u:object_r:usbguard_log_t,s0)
-/var/run/usbguard.*                       -- gen_context(system_u:object_r:usbguard_var_run_t,s0)
+/run/usbguard.*                       -- gen_context(system_u:object_r:usbguard_var_run_t,s0)


### PR DESCRIPTION
With the 1f76e522a ("Rename all /var/run file context entries to /run") selinux-policy commit, all /var/run file context entries moved to /run and the equivalency was inverted. Subsequently, changes in usbguard.fc need to be done, too, in a similar manner.