### PR TITLE
Allow usbguard to connect to XDM (GDM) socket

### DIFF
--- a/usbguard.te
+++ b/usbguard.te
@@ -139,3 +139,9 @@ ifdef(`systemd_homed_stream_connect',`
 		systemd_homed_stream_connect(usbguard_t)
 	')
 ')
+
+ifdef(`xserver_stream_connect_xdm',`
+	optional_policy(`
+		xserver_stream_connect_xdm(usbguard_t)
+	')
+')


### PR DESCRIPTION
On systems with GDM, `usbguard-daemon` generates SELinux AVC denials during IPC client authentication. The daemon calls `getpwuid_r()`/`getgrgid_r()` to resolve the connecting user's identity, which triggers the NSS lookup chain through `systemd-userdbd`. On GNOME Workstation systems, `systemd-userdbd` queries GDM via its socket at `/run/gdm/org.gnome.DisplayManager` (labeled `xdm_var_run_t`), and the current policy does not grant `usbguard_t` access to that socket.

This adds `xserver_stream_connect_xdm(usbguard_t)` wrapped in `ifdef`/`optional_policy` so it only takes effect when the XDM policy module is present.

## Steps to reproduce

1. Install usbguard and GDM:
   ```
   dnf install -y usbguard usbguard-selinux gdm
   ```
2. Generate policy and start both services:
   ```
   usbguard generate-policy > /etc/usbguard/rules.conf
   systemctl start gdm
   systemctl start usbguard
   ```
3. Create a user with usbguard IPC access:
   ```
   useradd -m testuser
   usbguard add-user testuser --devices=list
   systemctl restart usbguard
   ```
4. Run as that user:
   ```
   su - testuser -c "usbguard list-devices"
   ```
5. Check denials:
   ```
   ausearch -m avc --comm usbguard-daemon
   ```

## Result (before fix)

```
avc:  denied  { write } for  comm="usbguard-daemon"
  name="org.gnome.DisplayManager" dev="tmpfs"
  scontext=system_u:system_r:usbguard_t:s0
  tcontext=system_u:object_r:xdm_var_run_t:s0
  tclass=sock_file permissive=0
```

## Expected result (after fix)

No AVC denials. `usbguard list-devices` succeeds without SELinux interference.

## Scratch build

- Fedora rawhide (f45): [koji task 144636898](https://koji.fedoraproject.org/koji/taskinfo?taskID=144636898) — `usbguard-1.1.4-2.fc45` — **passed** (all arches)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2404086